### PR TITLE
fix: render html error

### DIFF
--- a/app/todo/views.py
+++ b/app/todo/views.py
@@ -43,7 +43,7 @@ def create_task(request, id):
             return redirect('tasks.index', id=current_folder.id)
     else:
         form = TaskForm()
-    return render(request, 'create_tasks.html', {'form': form}, {'id': current_folder.id})
+    return render(request, 'create_tasks.html', {'form': form, 'id': current_folder.id})
 
 def edit_task(request, id, task_id):
     #選ばれたタスクを取得する
@@ -56,4 +56,4 @@ def edit_task(request, id, task_id):
             return redirect('tasks.index', id=task.folder_id.id)
     else:
         form = TaskForm(instance=task)
-    return render(request, 'edit.html', {'form': form}, {'task':task})
+    return render(request, 'edit.html', {'form': form, 'task':task})


### PR DESCRIPTION
# #3 の修正
原因はrender関数へ不適切な辞書形式の形で渡されていないことが原因でした。

編集後の画面を張りますのでご確認お願いします
![image](https://github.com/sacky3105/django_app/assets/75029815/a6921312-02e7-495e-98ab-614cbbb24891)
![image](https://github.com/sacky3105/django_app/assets/75029815/542b4790-379a-4bc6-9758-4aefbd6848ca)
