### PR TITLE
add: static files refs

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,0 +1,4 @@
+.venv
+__pycache__/
+migration/
+static/

--- a/app/django_app/settings.py
+++ b/app/django_app/settings.py
@@ -24,7 +24,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = 'django-insecure-@ja&&g0*)rrsn67x9jpsmcit)60i5uyoe!%(xdbt%&_&ymi+iz'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 
 ALLOWED_HOSTS = [
     '192.168.100.185',

--- a/app/django_app/urls.py
+++ b/app/django_app/urls.py
@@ -14,9 +14,12 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import path, include, re_path
+from django.conf import settings
+from django.views.static import serve
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('folders/', include('todo.urls')),
+    re_path(r'^static/(?P<path>.*)$', serve,{'document_root': settings.STATIC_ROOT}),
 ]


### PR DESCRIPTION
## issueの番号
#15 

## どんな修正をしたのか
今回の問題は、staticディレクトリが参照しないようになっていることでした。
url.pyに/staticを把握させることで解決しました。ご確認お願いします。

## 備考
肝心の/staticはignoreしてあるので、python manage.py collectstaticして/staticを生成してください。
deployするときは、
- git pull
- cd app
- docker-compose down
- docker-compose build
- docker-compose up -d

をした後に内部でcollectstaticやrunserverの操作をしてください